### PR TITLE
Transformation of Greek time literals to the equivalent English ones

### DIFF
--- a/lib/string_extensions.dart
+++ b/lib/string_extensions.dart
@@ -1466,6 +1466,39 @@ extension MiscExtensions on String? {
         .toString();
   }
 
+  /// Replaces the Greek 12-hour time literals with the English 12-hour time literals.
+  /// πμ -> pm -> AM (ante meridiem / before mesembria / before noon)
+  /// μμ -> mm -> PM (post meridiem / after mesembria / after noon)
+  ///
+  /// For example:
+  /// ```
+  /// 05/12/2023 05:45:17 μ.μ.
+  /// ```
+  /// will return
+  /// ```
+  /// 05/12/2023 05:45:17 PM
+  /// ```
+  String get greekTimeLiteralToEnglish {
+    // If the String does not contain any Greek characters, return it as is.
+    String onlyGreek = this.onlyGreek!.replaceAll(" ", "");
+    if (onlyGreek.length <= 0) {
+      return this!;
+    }
+
+    // Translate all the Greek letters to the equivalent English ones.
+    String onlyEnglishCharacters = this.replaceGreek!.trim();
+
+    // Transform to the equivalent English time literals.
+    onlyEnglishCharacters =
+        onlyEnglishCharacters.replaceAll(".", "").toLowerCase();
+
+    onlyEnglishCharacters = onlyEnglishCharacters.contains("pm")
+        ? onlyEnglishCharacters.replaceAll("pm", "AM")
+        : onlyEnglishCharacters.replaceAll("mm", "PM");
+
+    return onlyEnglishCharacters;
+  }
+
   /// Returns the left side of the `String` starting from [char].
   ///
   /// If [char] doesn't exist, `null` is returned.

--- a/test/string_extensions_test.dart
+++ b/test/string_extensions_test.dart
@@ -978,6 +978,36 @@ void main() {
     },
   );
   test(
+    'Transforms the Greek μ.μ. time literal to the equivalent English PM',
+        () {
+      String greekAfterNoonTimeLiteral = "09:30:00 μ.μ.";
+      expect(
+          greekAfterNoonTimeLiteral
+              .greekTimeLiteralToEnglish,
+          "09:30:00 PM");
+    },
+  );
+  test(
+    'Transforms the Greek π.μ. time literal to the equivalent English AM',
+        () {
+      String greekBeforeNoonTimeLiteral = "09:30:00 π.μ.";
+      expect(
+          greekBeforeNoonTimeLiteral
+              .greekTimeLiteralToEnglish,
+          "09:30:00 AM");
+    },
+  );
+  test(
+    'Will return the same string if there is not any Greek time literal',
+        () {
+      String greekAfterNoonTimeLiteral = "09:30:00 mm";
+      expect(
+          greekAfterNoonTimeLiteral
+              .greekTimeLiteralToEnglish,
+          "09:30:00 mm");
+    },
+  );
+  test(
     'Get the left side of the string from a specific character',
     () {
       String t1 = 'peanut-10-butter';


### PR DESCRIPTION
Introducing translation for Greek time literals to the equivalent English ones. This can come handy when there is a need to convert a string to datetime, but the initial string contains Greek time literals.

I've stumbled upon this need while working on [black-out](https://github.com/gbrandtio/black-out), where DEDDHE returns/presents the electricity outages timings on a 12-hour basis, including time literals in Greek.