### PR TITLE
Implementation of containsAnyGreekCharacters

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: dart-lang/setup-dart@9a04e6d73cca37bd455e0608d7e5092f881fd603
 
       - name: Install dependencies
-        run: dart pub get
+        run: flutter pub get
 
       - name: Verify formatting
         run: dart format --output=none --set-exit-if-changed .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dart-lang/setup-dart@9a04e6d73cca37bd455e0608d7e5092f881fd603
+      - uses: subosito/flutter-action@v2
 
       - name: Install dependencies
         run: flutter pub get

--- a/lib/string_extensions.dart
+++ b/lib/string_extensions.dart
@@ -1490,8 +1490,7 @@ extension MiscExtensions on String? {
   /// ```
   String get greekTimeLiteralToEnglish {
     // If the String does not contain any Greek characters, return it as is.
-    String onlyGreek = this.onlyGreek!.replaceAll(" ", "");
-    if (onlyGreek.length <= 0) {
+    if (!this.containsAnyGreekCharacter) {
       return this!;
     }
 

--- a/lib/string_extensions.dart
+++ b/lib/string_extensions.dart
@@ -203,6 +203,16 @@ extension MiscExtensions on String? {
     return this!.replaceAll(regex, '');
   }
 
+  /// Checks whether the supplied string contains any Greek character.
+  bool get containsAnyGreekCharacter {
+    if (this.isBlank) {
+      return false;
+    }
+
+    String onlyGreekLetters = this.onlyGreek!.replaceAll(" ", "");
+    return onlyGreekLetters.isNotEmpty;
+  }
+
   /// Returns only the Latin OR Greek characters from the `String`.
   /// ### Example
   /// ```dart

--- a/lib/string_helpers.dart
+++ b/lib/string_helpers.dart
@@ -383,4 +383,12 @@ class StringHelpers {
     'Ώ': 'o',
     'ώ': 'o',
   };
+
+  static Map<String, String> lettersToSymbols = {
+    ' ': ' ',
+    '!': 'i',
+    '@': 'a',
+    '\$': 's',
+    '#': 'e'
+  };
 }

--- a/test/string_extensions_test.dart
+++ b/test/string_extensions_test.dart
@@ -124,6 +124,19 @@ void main() {
       expect(' '.onlyGreek, ' ');
     },
   );
+  test('Checks whether a string contains any Greek character', () {
+    String stringWithoutGreekCharacters = "ABcdE#h*j klM";
+    expect(stringWithoutGreekCharacters.containsAnyGreekCharacter, false);
+
+    String stringWithGreekCharacters = " ABcdE#hα*jklM ";
+    expect(stringWithGreekCharacters.containsAnyGreekCharacter, true);
+
+    String emptyString = " ";
+    expect(emptyString.containsAnyGreekCharacter, false);
+
+    String none = "";
+    expect(none.containsAnyGreekCharacter, false);
+  });
   test(
     'Converts the string to camel case',
     () {


### PR DESCRIPTION
Currently, the `onlyGreek` method offers this functionality but it will return a string with empty spaces, if the supplied string contains any of them.

This is fine, as `onlyGreek` is intended to do so (based on it's current unit tests). However, adds an extra step for use cases that we just need to know if a string contains any greek characters or not.

Also, refactored the `greekTimeLiteralToEnglish` to use the new method instead of the internal check.