### PR TITLE
Leet String to Normal String - Second attempt to address #23

### DIFF
--- a/lib/string_extensions.dart
+++ b/lib/string_extensions.dart
@@ -2202,6 +2202,41 @@ extension MiscExtensions on String? {
     return leetLetters.join();
   }
 
+  /// Transforms the leet symbols of a string to their equivalent letters.
+  ///
+  /// For example:
+  /// ```
+  /// th!s !s just @ t3st
+  /// ```
+  /// will produce:
+  /// ```
+  /// this is just a test
+  /// ```
+  String? get fromLeet {
+    List<String> stringWithSymbols = this!.split('');
+    List<String> letters = [];
+
+    for (int i = 0; i < stringWithSymbols.length; i++) {
+      String currentCharacter = stringWithSymbols[i].toLowerCase().trim();
+      if (currentCharacter.isEmpty) {
+        letters.add(" ");
+      }
+
+      if (StringHelpers.leetAlphabet.containsKey(currentCharacter)) {
+        letters.add(currentCharacter);
+      } else {
+        // The current character is a leet symbol - find it's equivalent letter.
+        StringHelpers.leetAlphabet.forEach((key, value) {
+          if (value.contains(currentCharacter)) {
+            letters.add(key);
+          }
+        });
+      }
+    }
+
+    return letters.join();
+  }
+
   /// Checks if the `String` provided is a valid credit card number using Luhn Algorithm.
   ///
   /// ### Example

--- a/test/string_extensions_test.dart
+++ b/test/string_extensions_test.dart
@@ -1412,4 +1412,13 @@ void main() {
     expect("HELLOworld!".isMixedCase(), equals(true));
     expect("HelloWORLD!".isMixedCase(), equals(true));
   });
+
+  test(
+      "Transforms a string with leet symbols to a string with their equivalent letters",
+      () {
+    expect("th!s !s just @ t3st".fromLeet, "this is just a test");
+    expect("this is just a test".fromLeet, "this is just a test");
+    expect("".fromLeet, "");
+    expect(" ".fromLeet, " ");
+  });
 }


### PR DESCRIPTION
Based on the feedback received on https://github.com/esentis/string_extensions/pull/36 have seen that there is current support for leet symbols as well as a function that transforms a normal string to a leet string.

This is a second attempt to address https://github.com/esentis/string_extensions/issues/23 by implementing a method that transforms a string with leet symbols to a string that will contain the equivalent letters.